### PR TITLE
Some small fixes and enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:2.7-slim
+
+ARG workdir=juniper-config-parser
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y vim openssh-client iputils-ping dnsutils graphviz
+
+RUN mkdir -p /$workdir
+ADD . /$workdir
+WORKDIR /$workdir
+
+RUN pip install --upgrade pip
+RUN pip install lxml netaddr beautifulsoup4 pillow pexpect

--- a/README.md
+++ b/README.md
@@ -30,9 +30,22 @@ dot viz.viz -Tjpg -o DMZ-Interne.jpg
 ## Motivation
 
 This script has been first developed at Cergy Pontoise University by JT Graveaud, IT Network and Infrastructure Manager.<br>
-The first need of this script was to understand and to see policies, SNAT and DNAT more clearly in order to clean thousands of policies that became unreadable years after years. 
+The first need of this script was to understand and to see policies, SNAT and DNAT more clearly in order to clean thousands of policies that became unreadable years after years.
 
 ## Installation
+
+### Usage with Docker
+
+The python environment can be build as a local docker container with all the dependencies installed automatically, so they don't need to be managed on the host computer.
+
+Build the Docker image with tag 'config-parser' (the dot means that it uses the Dockerfile provided in the current directory):
+
+    docker build -t config-parser .
+
+Start the container with a bind mount in order to keep files in the container in sync with the host:
+
+    docker run -v $(pwd):/juniper-config-parser -it config-parser bash
+
 
 ------------------
 Quick starting User's guide & useful command lines:
@@ -57,7 +70,7 @@ $ ../common/pysec.py --enc -k key_default.enc
 - 3/ eventually get all SRX configuration data and SRX counters to get all those information in a text format
    and manipulate those data without fetching the SRX all the time.<br>
    This way you can historize SRX configuration file.
-   
+
 $ ./srx.py -getconf
 
 Note: the command above generate the following configuration and counters in the txt Format stored in "./data" directory<br>

--- a/common/pysec.py
+++ b/common/pysec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2007 Brandon Sterne
 # Licensed under the MIT license.
 # http://brandon.sternefamily.net/wp-content/uploads/2007/06/pyAES.txt

--- a/srx/srx.py
+++ b/srx/srx.py
@@ -407,7 +407,7 @@ if PARAM.getconf:
     print "Timeout", cmd
     exit()
 
-  with open('data/srx-snat_'+srx_ip+'.txt', 'w') as fd:
+  with open('data/srx_snat_'+srx_ip+'.txt', 'w') as fd:
     cntidx = fd.write(policy_sequences_indexes)
     fd.close()
 
@@ -420,7 +420,7 @@ if PARAM.getconf:
     print "Timeout", cmd
     exit()
         
-  with open('data/srx-dnat_'+srx_ip+'.txt', 'w') as fd:
+  with open('data/srx_dnat_'+srx_ip+'.txt', 'w') as fd:
     cntidx = fd.write(policy_sequences_indexes)
     fd.close()
 
@@ -444,11 +444,11 @@ try:
     policy_sequences_indexes = fd.read()
 
   # get read the TXT counter SNat file
-  with open('data/srx-snat_'+srx_ip+'.txt') as fd:
+  with open('data/srx_snat_'+srx_ip+'.txt') as fd:
     snat_counters_file = fd.read()
 
   # get read the TXT counter DNat file
-  with open('data/srx-dnat_'+srx_ip+'.txt') as fd:
+  with open('data/srx_dnat_'+srx_ip+'.txt') as fd:
     dnat_counters_file = fd.read()
 except IOError, Except_Argument:
   print Except_Argument

--- a/srx/srx.py
+++ b/srx/srx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------
 # Creation Date : Jan/14/2017

--- a/srx/srx.py
+++ b/srx/srx.py
@@ -294,7 +294,7 @@ def param_missing(param_name):
 def get_content_srx(login, ip, pw, cmd):
   output = ''
   child = pexpect.spawn ('ssh '+login+'@'+ip+' "'+cmd+'"')
-  child.timeout = 90
+  child.timeout = 180
   child.maxread = 100000
   child.waitnoecho()
   child.sendline(pw+"\n")


### PR DESCRIPTION
Hi,
please have a look at the below change proposals:

- A Dockerfile so you can build and run the python environment in a container. I had problems installing the dependencies locally on my host, and I assume others will have problems following the provided installation information on their hosts too, because currently it is not designed to be portable. The Dockerfile provides full portability across platforms, but of course it's usage is still optional if one wants to run the script locally.

- Use env in the shebang of the scripts to dynamically detect the Python interpreter path. Currently, the path is hard-coded and doesn't necessarily apply to other platforms.

- Unified output file name for the srx output files. In the original script, the (S/D-)NAT files are named "srx-" on contrast to "srx_" as the other ones. Another approach would be to simply include "srx-" in the .gitignore file, but I consider it better to have the names unified.

- An increased timeout for pexpect, because 90 seconds aren't always enough for some SRX clusters.

Kind regards,
Ben
